### PR TITLE
replace xyce with ngspice

### DIFF
--- a/openfasoc/common/platform_config.json
+++ b/openfasoc/common/platform_config.json
@@ -1,5 +1,5 @@
 {
-  "simTool": "xyce",
+  "simTool": "ngspice",
   "simMode": "partial",
   "open_pdks_GCP": "/shared/OpenLane/pdks/sky130A",
   "open_pdks_GHA": "/home/runner/work/sky130A",


### PR DESCRIPTION
replace xyce with ngspice since all available generators support ngspice. This will make the CI of ldo-gen to pass.